### PR TITLE
Use full commit SHA instead of short

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -48,10 +48,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: GeoNet/yq@bbe3055
+      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4
       - uses: actions/setup-go@v4
       - uses: sigstore/cosign-installer@main
-      - uses: GeoNet/setup-crane@00c9e93
+      - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c
       - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         go-version: ${{ steps.run-info.outputs.go-version }}
         cache-dependency-path: go.sum
-    - uses: GeoNet/setup-ko@f3c6980
+    - uses: GeoNet/setup-ko@f3c6980bb213dc8bb4856f52598a9230d910d06f
     - id: build
       env:
         KO_DOCKER_REPO: ${{ steps.run-info.outputs.ko-docker-repo }}


### PR DESCRIPTION
Got some errors when trying to call actions

> Unable to resolve action `GeoNet/setup-crane@00c9e93`, the provided ref `00c9e93` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c` instead.. Unable to resolve action `GeoNet/yq@bbe3055`, the provided ref `bbe3055` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `bbe305500687a5fe8498d74883c17f0f06431ac4` instead