### PR TITLE
Fix ref for yq in repo sync workflow

### DIFF
--- a/.github/workflows/github-repo-fork-sync.yml
+++ b/.github/workflows/github-repo-fork-sync.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
-      - uses: mikefarah/yq@master
+      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4
       - id: set
         run: |
           echo "matrix=$(jq '.repos' -r -c <<< "$(yq e . -o json config/fork-sync.yaml)")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
the fork ref was meant to be used instead of the upstream ref