### PR TITLE
Fix input name for repo sync

### DIFF
--- a/.github/workflows/reusable-github-repo-fork-sync.yml
+++ b/.github/workflows/reusable-github-repo-fork-sync.yml
@@ -20,4 +20,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token }}
       run: |
-        gh repo sync --force ${{ inputs.repo }}
+        gh repo sync --force ${{ inputs.name }}


### PR DESCRIPTION
The job did exactly what it was told, but the input should've been name instead of repo.

![image](https://user-images.githubusercontent.com/8588826/234723612-2cf2fc33-b953-4feb-a31d-f56b35a21361.png) (from https://github.com/GeoNet/Actions/actions/runs/4814286989/jobs/8571786578)