### PR TITLE
Add reusable go test workflow

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -1,0 +1,21 @@
+name: reusable go test
+on:
+  workflow_call: {}
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - id: run-info
+        name: collect job run info
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
+        run: |
+          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: ${{ steps.run-info.outputs.go-version }}
+          cache-dependency-path: go.sum
+      - name: test
+        id: test
+        run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -361,6 +361,21 @@ Whilst not generally recommend, this config can be override per action use, with
 
 for configuration see [`on.workflow_call.inputs` in .github/workflows/reusable-golangci-lint.yml](.github/workflows/reusable-golangci-lint.yml).
 
+### Go test
+
+Run `go test` against the codebase
+
+```yaml
+name: go test
+on:
+  push: {}
+  pull_request: {}
+  workflow_dispatch: {}
+jobs:
+  build:
+    uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
+```
+
 ## Other documentation
 
 ### Container image signing


### PR DESCRIPTION
Adds a reusable workflow for testing a Go codebase, using the standard testing entrypoint