### PR TITLE
Add input to go-container-apps to disable scanning

### DIFF
--- a/.github/workflows/reusable-go-container-apps.yml
+++ b/.github/workflows/reusable-go-container-apps.yml
@@ -63,6 +63,14 @@ on:
         type: boolean
         default: false
         required: false
+        description: |
+          specifies whether to auto merge PRs for Go version updates to go.mod files
+      containerScanningEnabled:
+        type: boolean
+        default: false
+        required: false
+        description: |
+          specifies whether to enable container scanning for each image built
 jobs:
   build:
     if: ${{ github.event_name == 'workflow_call' || github.event_name == 'push' || github.event_name == 'release' }}
@@ -71,7 +79,7 @@ jobs:
       registryOverride: ${{ inputs.registryOverride }}
       paths: ${{ inputs.paths }}
   scan:
-    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'push' || github.event_name == 'release' }}
+    if: ${{ (github.event_name == 'workflow_call' || github.event_name == 'push' || github.event_name == 'release') && inputs.containerScanningEnabled }}
     needs: build
     uses: GeoNet/Actions/.github/workflows/reusable-container-image-scan.yml@main
     with:

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  actions: read
   packages: write
   contents: write
   pull-requests: write
@@ -513,6 +514,14 @@ permissions:
 jobs:
   go-container-apps:
     uses: BobyMCbobs/sample-ko-monorepo/.github/workflows/reusable-go-container-apps.yml@main
+    # with:
+    #   registryOverride: string
+    #   paths: string
+    #   imagePromotionConfigLiteral: |
+    #     string
+    #   imagePromotionConfigPath: string
+    #   updateGoVersionAutoMerge: boolean
+    #   containerScanningEnabled: boolean
 ```
 
 for configuration see [`on.workflow_call.inputs` in .github/workflows/reusable-go-container-apps.yml](.github/workflows/reusable-go-container-apps.yml).


### PR DESCRIPTION
disable container scanning default, requiring explicit enabling