### PR TITLE
Add stale submission

### DIFF
--- a/.github/workflows/reusable-stale-submission.yml
+++ b/.github/workflows/reusable-stale-submission.yml
@@ -1,4 +1,4 @@
-name: stale
+name: reusable stale submission
 on:
   workflow_call:
     inputs:

--- a/README.md
+++ b/README.md
@@ -500,13 +500,13 @@ links:
 marks an issue or PR as stale after 90 days and then closes it after a further 30 days
 
 ```yaml
-name: stale
+name: stale submission
 on:
   schedule:
   - cron: '0 1 * * *'
 jobs:
   stale:
-    uses: GeoNet/Actions/.github/workflows/reusable-stale-submission.yaml@main
+    uses: GeoNet/Actions/.github/workflows/reusable-stale-submission.yml@main
     # with:
     #   days-before-stale: number
     #   days-before-close: number


### PR DESCRIPTION
adds a stale label and message to an issue or PR after 90 days (by default) and closing it after a further 30 days (by default).

#### Why have this behaviour?

- ensures attention and interest on issues
- move fast
- focus on what's active