### PR TITLE
Tidy Go version to use in Go workflows

### DIFF
--- a/.github/workflows/reusable-container-image-scan.yml
+++ b/.github/workflows/reusable-container-image-scan.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - name: quay crane login

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -6,13 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+        with:
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: test
         id: test

--- a/.github/workflows/reusable-go-vet.yml
+++ b/.github/workflows/reusable-go-vet.yml
@@ -6,13 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: vet
         id: vet

--- a/.github/workflows/reusable-gofmt.yml
+++ b/.github/workflows/reusable-gofmt.yml
@@ -6,13 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: gofmt
         id: gofmt

--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -14,13 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
           cache: false
       - name: write .golangci.yml
         if: ${{ inputs.config }}

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -39,7 +39,6 @@ jobs:
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
         run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
           if [ -n "${{ inputs.registryOverride }}" ]; then
             KO_DOCKER_REPO="${{ inputs.registryOverride }}"
           fi
@@ -52,7 +51,7 @@ jobs:
           fi
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - uses: GeoNet/setup-ko@f3c6980bb213dc8bb4856f52598a9230d910d06f # main
       - id: build


### PR DESCRIPTION
this was a case of _that was already a feature_, so this PR adopts using _go-version-file_