### PR TITLE
Add reusable go build smoke test

### DIFF
--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -1,0 +1,33 @@
+name: Reusable Go build smoke test
+on:
+  workflow_call:
+    inputs:
+      paths:
+        required: false
+        type: string
+        description: |
+          the Go entrypoint paths for applications, where there they have `package main`
+          e.g: ./cmd/thing1 ./cmd/thing2
+jobs:
+  go-build-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - id: run-info
+        name: collect job run info
+        run: |
+          if [ -n "${{ inputs.paths }}" ]; then
+            echo "paths=$(echo '${{ inputs.paths }}' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          else
+            PATHS="$(grep -r 'package main' | sort | cut -d ':' -f1 | grep '.go$' | xargs -n 1 dirname | sort | uniq | grep -v vendor | xargs -i echo './{}' | xargs)"
+            echo "paths="$PATHS"" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - id: build
+        env:
+          PATHS: ${{ steps.run-info.outputs.paths }}
+        run: |
+          echo "$PATHS" | tr ' ' '\n' | xargs -i -n 1 go build -o /dev/null './{}'

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ jobs:
           echo "matrix=$(find $FOLDER -mindepth 1 -maxdepth 1 -type d | xargs -n 1 basename | xargs | yq 'split(" ")|.[]|{"target":.}' -ojson | jq -rcM -s .)" >> $GITHUB_OUTPUT
       - name: check output
         run: |
-          jq . <<< '${{ steps.prepare.outputs.matrix }}'
+          jq . <<< '${{ steps.set.outputs.matrix }}'
 
   build:
     needs: prepare
@@ -428,6 +428,28 @@ jobs:
   govulncheck:
     uses: GeoNet/Actions/.github/workflows/reusable-govulncheck.yml@main
 ```
+
+### Go build smoke test
+
+Performs `go build -o /dev/null $PATH` to ensure that the programs compile.
+Note: does not cache or push the binary artifacts anywhere.
+
+Example:
+```yaml
+name: build
+
+on:
+  push: {}
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    uses: GeoNet/Actions/.github/workflows/reusable-go-build-smoke-test.yml@main
+    # with:
+    #   paths: ./cmd/coolapp
+```
+
+for configuration see [`on.workflow_call.inputs` in .github/workflows/reusable-go-build-smoke-test.yml](.github/workflows/reusable-go-build-smoke-test.yml).
 
 ### Presubmit commit policy conformance
 


### PR DESCRIPTION
Performs `go build -o /dev/null $PATH` to ensure that the programs compile