### PR TITLE
Update checkout config for promotion

### DIFF
--- a/.github/workflows/reusable-container-image-promotion.yml
+++ b/.github/workflows/reusable-container-image-promotion.yml
@@ -82,6 +82,9 @@ jobs:
         include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - name: Login to quay.io


### PR DESCRIPTION
attempts to fix the errors
```
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +8fc71439a419b0a89dc75e914c7d4faa64198f7d:refs/remotes/origin/promotion
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/GeoNet/field/' not found
  Error: The process '/usr/bin/git' failed with exit code 128
```

from https://github.com/GeoNet/field/actions/runs/4985666523/jobs/8925812806