### PR TITLE
Set timeout-minutes to 30 on build workflows

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -54,6 +54,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       images: ${{ steps.image.outputs.image }}
     steps:

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       images: ${{ steps.build.outputs.images }}
     steps:
@@ -55,6 +56,7 @@ jobs:
           cache-dependency-path: go.sum
       - uses: GeoNet/setup-ko@f3c6980bb213dc8bb4856f52598a9230d910d06f # main
       - id: build
+        name: build
         env:
           KO_DOCKER_REPO: ${{ steps.run-info.outputs.ko-docker-repo }}
           IMAGES_PATH: ${{ steps.run-info.outputs.paths }}


### PR DESCRIPTION
30 minutes is a pretty big number and won't be expected to take that long but will surely cause 
https://github.com/GeoNet/field/actions/runs/4986822964/jobs/8928146171
not to happen