### PR TITLE
Print packages built in Go build smoke test

### DIFF
--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           PATHS: ${{ steps.run-info.outputs.paths }}
         run: |
-          echo "$PATHS" | tr ' ' '\n' | xargs -i -n 1 go build -o /dev/null './{}'
+          echo "$PATHS" | tr ' ' '\n' | xargs -i -n 1 go build -v -o /dev/null './{}'


### PR DESCRIPTION
adds a `-v` flag to `go build`.
Print packages as they are built. More verbosity will show better what's happening.