### PR TITLE
Update go-container-apps to only build image on main

### DIFF
--- a/.github/workflows/reusable-go-container-apps.yml
+++ b/.github/workflows/reusable-go-container-apps.yml
@@ -71,6 +71,12 @@ on:
         required: false
         description: |
           specifies whether to enable container scanning for each image built
+      containerBuildEnabled:
+        type: boolean
+        default: ${{ github.ref == 'refs/heads/main' }}
+        required: false
+        description: |
+          specifies whether to enable container scanning for each image built
 jobs:
   go-build:
     if: ${{ github.event_name == 'workflow_call' || github.event_name == 'push' }}
@@ -78,7 +84,7 @@ jobs:
     with:
       paths: ${{ inputs.paths }}
   build:
-    if: ${{ contains(fromJSON('["workflow_call", "push", "release"]'), github.event_name) }}
+    if: ${{ contains(fromJSON('["workflow_call", "push", "release"]'), github.event_name) && inputs.containerBuildEnabled }}
     uses: GeoNet/Actions/.github/workflows/reusable-ko-build.yml@main
     with:
       registryOverride: ${{ inputs.registryOverride }}

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ jobs:
     #   imagePromotionConfigPath: string
     #   updateGoVersionAutoMerge: boolean
     #   containerScanningEnabled: boolean
+    #   containerBuildEnabled: boolean
 ```
 
 for configuration see [`on.workflow_call.inputs` in .github/workflows/reusable-go-container-apps.yml](.github/workflows/reusable-go-container-apps.yml).


### PR DESCRIPTION
due to image build times in big repos, default to not building container image unless on main branch.
Use go-build-smoke-test to determine if the software builds