### PR TITLE
Add `-cover` to reusable-go-test

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -12,4 +12,18 @@ jobs:
           cache-dependency-path: go.sum
       - name: test
         id: test
-        run: go test -v ./...
+        run: |
+          go test -v -coverprofile /tmp/coverage.out -cover ./...
+      - name: create coverage html
+        id: coverage-html
+        run: |
+          go tool cover -html=/tmp/coverage.out -o /tmp/coverage.html
+      - name: Upload test log
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: always()
+        with:
+          name: test-results
+          path: |
+            /tmp/coverage.out
+            /tmp/coverage.html
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ jobs:
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
 ```
 
+test coverage results upload to job artifacts, found at the bottom of a job summary page.
+
 ### Go vulnerability check
 
 Run `govulncheck` against the codebase


### PR DESCRIPTION
see the amount of test coverage, per go packages with tests