### PR TITLE
Update path normalisation for image promotion config

### DIFF
--- a/.github/workflows/reusable-container-image-promotion.yml
+++ b/.github/workflows/reusable-container-image-promotion.yml
@@ -157,8 +157,10 @@ jobs:
           gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           gh auth status
       - id: run-info
+        env:
+          CONFIG_PATH: ${{ inputs.configPath }}
         run: |
-          echo "configPath=$(echo "${{ inputs.configPath }}" | sed 's,^./,,g')" >> $GITHUB_OUTPUT
+          echo "configPath=$(realpath "$CONFIG_PATH" | sed "s,^$PWD/,,g")" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version-file: go.mod


### PR DESCRIPTION
for an input like _./images/config.yaml_, should always expect it is normalised to _images/config.yaml_