### PR TITLE
feat: enable gosec in golangci-lint by default

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -28,4 +28,4 @@ jobs:
         uses: GeoNet/golangci-lint-action@4cb96975783006316142911dac808e71dd8b0b40 # master
         with:
           version: v1.52.2
-          args: --timeout 30m
+          args: --timeout 30m -E gosec


### PR DESCRIPTION
ensures that the _gosec_ linter is enabled for all golangci-lint jobs