### PR TITLE
feat: make output a bit nicer to view images built

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -163,4 +163,4 @@ jobs:
         if: ${{ inputs.push }}
         id: result
         run: |
-          echo "Build, pushed and signed: ${{ steps.image.outputs.image }}"
+          echo -e "Built, pushed and signed:\n\n$(echo ${{ steps.image.outputs.image }} | sed 's/,/\n/g' | sed 's/^/- /g')"

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -80,4 +80,4 @@ jobs:
       - name: image result
         id: result
         run: |
-          echo "Build, pushed and signed: $(echo ${{ steps.build.outputs.images }} | tr ',' ' ')"
+          echo -e "Built, pushed and signed:\n\n$(echo ${{ steps.build.outputs.images }} | sed 's/,/\n/g' | sed 's/^/- /g')"


### PR DESCRIPTION
make output like

```
Built, pushed and signed:
- ghcr.io/geonet/lasso/coastal-crex-build@sha256:f0c13c679b7ee6e8e0ae58a2ffdf24a134028ba2950fefabe06be1a94a54b7d9
- ghcr.io/geonet/lasso/coastal-crex-client@sha256:ca01e73ce7411b89a946777342de3acbda0dd2ad2fc8108b3eab670b3125fec6
- ghcr.io/geonet/lasso/coastal-gts-client@sha256:68fdf3bcf91f23d6258e84208123f59707f47440fefc378b809e0261d420cba5
- ghcr.io/geonet/lasso/dart-alert-files@sha256:e9c6f7e01a463f7ef219e1cee72a080c6610d246540caabdb074e477d3888fbf
- ghcr.io/geonet/lasso/holdings-listen-slink@sha256:7a1bd7bcca41c92f0d4f3df5f443cff58f9551622dc416cef0e1bb8f869b2e78
```

instead of a single-lined note