### PR TITLE
chore: use go stable for non-go workflows

### DIFF
--- a/.github/workflows/reusable-container-image-promotion.yml
+++ b/.github/workflows/reusable-container-image-promotion.yml
@@ -99,8 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version: stable
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - name: Login to quay.io
@@ -172,8 +171,7 @@ jobs:
           echo "configPath=$(realpath "$CONFIG_PATH" | sed "s,^$PWD/,,g")" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version: stable
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - name: Login to quay.io

--- a/.github/workflows/reusable-container-image-scan.yml
+++ b/.github/workflows/reusable-container-image-scan.yml
@@ -38,8 +38,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version: stable
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - name: quay crane login

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -70,8 +70,7 @@ jobs:
       - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version: stable
           check-latest: true
       - uses: sigstore/cosign-installer@dd6b2e2b610a11fd73dd187a43d57cc1394e35f9 # v3.0.5
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main

--- a/.github/workflows/reusable-presubmit-github-actions-workflow-validator.yml
+++ b/.github/workflows/reusable-presubmit-github-actions-workflow-validator.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version: stable
           check-latest: true
       - name: download schema
         run: |

--- a/.github/workflows/reusable-presubmit-readme-toc.yml
+++ b/.github/workflows/reusable-presubmit-readme-toc.yml
@@ -7,6 +7,8 @@ on:
         default: README.md
         description: |
           the path to the README.md
+env:
+  VERSION_MDTOC: 7993442ed6a3dd528d34eb36b36cb085c17e17b0
 jobs:
   presubmit-readme-toc:
     runs-on: ubuntu-latest
@@ -17,14 +19,13 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version: stable
           check-latest: true
       - env:
           READMEPATH: ${{ inputs.readmePath }}
         name: generate table of contents
         run: |
-          go run sigs.k8s.io/mdtoc@latest --inplace $READMEPATH
+          go run sigs.k8s.io/mdtoc@$VERSION_MDTOC --inplace $READMEPATH
       - id: changes
         name: determine changes
         env:


### PR DESCRIPTION
- these workflows don't need to rely on a go.mod in a repo
- pin mdtoc to a version