### PR TITLE
feat: add eval for test setup commands

### DIFF
--- a/.github/workflows/reusable-go-apps.yml
+++ b/.github/workflows/reusable-go-apps.yml
@@ -14,6 +14,11 @@ on:
         required: false
         description: |
           specifies whether to auto merge PRs for Go version updates to go.mod files
+      testSetup:
+        type: boolean
+        required: false
+        description: |
+          shell commands to setup the test environment
 jobs:
   go-build:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
@@ -29,6 +34,8 @@ jobs:
   go-test:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
+    with:
+      setup: ${{ inputs.testSetup }}
   go-vet:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-vet.yml@main

--- a/.github/workflows/reusable-go-container-apps.yml
+++ b/.github/workflows/reusable-go-container-apps.yml
@@ -83,6 +83,11 @@ on:
         type: boolean
         description: |
           set to true to push an image to a registry. When set to false, it will build and exit
+      testSetup:
+        type: boolean
+        required: false
+        description: |
+          shell commands to setup the test environment
     outputs:
       images:
         value: ${{ jobs.build.outputs.images }}
@@ -113,6 +118,8 @@ jobs:
   go-test:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
+    with:
+      setup: ${{ inputs.testSetup }}
   go-vet:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-vet.yml@main

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -1,6 +1,12 @@
 name: reusable go test
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      setup:
+        required: false
+        type: string
+        description: |
+          shell commands to setup the test environment
 jobs:
   go-test:
     runs-on: ubuntu-latest
@@ -14,6 +20,9 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
           check-latest: true
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - name: test
         id: test
         run: |


### PR DESCRIPTION
Will allow for adding of arbitrary commands to setup the test environment; for example
```
  testSetup: |
    sudo apt-get install -y lolcat
    docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:15.5-alpine
```

intended for https://github.com/GeoNet/fdsn/pull/238