### PR TITLE
fix: syntax for default push value in go-container-apps

### DIFF
--- a/.github/workflows/reusable-go-container-apps.yml
+++ b/.github/workflows/reusable-go-container-apps.yml
@@ -79,7 +79,7 @@ on:
           specifies whether to enable container scanning for each image built
       push:
         required: false
-        default: ${{ github.ref = 'refs/heads/main' }}
+        default: ${{ github.ref == 'refs/heads/main' }}
         type: boolean
         description: |
           set to true to push an image to a registry. When set to false, it will build and exit


### PR DESCRIPTION
lil' hot fix