### PR TITLE
feat: add setup for shell command before docker build

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -81,6 +81,11 @@ on:
         required: false
         description: |
           the name of the session to use for AssumeRole(WithWebIdentity).
+      setup:
+        type: string
+        required: false
+        description: |
+          shell commands to setup the build environment
     outputs:
       image:
         value: ${{ jobs.build.outputs.image }}
@@ -124,6 +129,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - id: run-info
         name: collect job run info
         env:


### PR DESCRIPTION
implement existing patterns for builds

intended for use in https://github.com/GeoNet/fdsn/pull/238 to use setup to copy the Dockerfile template and append the CMD statement per image.