### PR TITLE
fix: dockerfile lint outputs

### DIFF
--- a/.github/workflows/reusable-dockerfile-lint.yml
+++ b/.github/workflows/reusable-dockerfile-lint.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           INPUTS: ${{ inputs.dockerfiles }}
         run: |
-          DOCKERFILES="$(find . -name '*Dockerfile*' -or -name '*Containerfile')"
+          DOCKERFILES="$(find . -name '*Dockerfile*' -or -name '*Containerfile' | xargs | tr ' ' ',')"
           if [ -n "$INPUTS" ]; then
             DOCKERFILES="$INPUTS"
           fi
@@ -28,4 +28,5 @@ jobs:
         env:
           DOCKERFILES: ${{ steps.run-info.outputs.dockerfiles }}
         run: |
-          docker run --rm -v "$PWD:$PWD" --workdir "$PWD" ghcr.io/geonet/base-images/hadolint/hadolint:v2.12.0-alpine hadolint $DOCKERFILES
+          echo "linting: ${DOCKERFILES//,/ }"
+          docker run --rm -v "$PWD:$PWD" --workdir "$PWD" ghcr.io/geonet/base-images/hadolint/hadolint:v2.12.0-alpine hadolint ${DOCKERFILES//,/ }


### PR DESCRIPTION
use comma separated list for Dockerfile discovery in output to lint step.
GitHub Actions doesn't handle too well to multi-line values.

tested in https://github.com/BobyMCbobs/sample-docker-monorepo/actions/runs/5606286054/jobs/10256292679#step:4:1