### PR TITLE
feat: add setup to go-build and golangci-lint

### DIFF
--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -8,6 +8,11 @@ on:
         description: |
           the Go entrypoint paths for applications, where there they have `package main`
           e.g: ./cmd/thing1 ./cmd/thing2
+      setup:
+        required: false
+        type: string
+        description: |
+          shell commands to setup the test environment
 jobs:
   go-build-smoke-test:
     runs-on: ubuntu-latest
@@ -30,6 +35,9 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
           check-latest: true
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - id: build
         env:
           PATHS: ${{ steps.run-info.outputs.paths }}

--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -8,6 +8,11 @@ on:
         description: |
           a .golangci.yml configuration file.
           Warning: setting this field will override an existing config
+      setup:
+        required: false
+        type: string
+        description: |
+          shell commands to setup the test environment
 jobs:
   golangci:
     name: lint
@@ -27,6 +32,9 @@ jobs:
         run: |
           echo "Using config:"
           echo '${{ inputs.config }}' | tee .golangci.yml
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - name: golangci-lint
         uses: GeoNet/golangci-lint-action@4cb96975783006316142911dac808e71dd8b0b40 # master
         with:


### PR DESCRIPTION
to do things like install external dependencies before running

intended to fix jobs related to https://github.com/GeoNet/4D-Ashfall/pull/33, such as go-build smoke test and golangci-lint