### PR TITLE
style: Update convention types list

### DIFF
--- a/.github/workflows/reusable-policy-conformance.yml
+++ b/.github/workflows/reusable-policy-conformance.yml
@@ -27,12 +27,15 @@ on:
                 conventional:
                   types:
                     - chore
+                    - ci
                     - docs
-                    - perf
+                    - feat
+                    - fix
                     - refactor
+                    - release
+                    - revert
                     - style
                     - test
-                    - release
                   scopes: [".*"]
 jobs:
   conform:


### PR DESCRIPTION
Update the list to cover a wider range of messages that have been used across different repositories so far. To avoid overuse of the term `chore`

This update includes some that @ozym has been using already in `ac-tools`, `fix` and `ci`.