### PR TITLE
fix: use fixed version of crane

### DIFF
--- a/.github/workflows/reusable-container-image-promotion.yml
+++ b/.github/workflows/reusable-container-image-promotion.yml
@@ -1,4 +1,6 @@
 name: reusable container image promotion
+env:
+  VERSION_CRANE: v0.16.1
 on:
   workflow_call:
     inputs:
@@ -125,6 +127,8 @@ jobs:
           go-version: stable
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
+        with:
+          version: ${{ env.VERSION_CRANE }}
       - name: Login to quay.io
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         env:
@@ -222,6 +226,8 @@ jobs:
           go-version: stable
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
+        with:
+          version: ${{ env.VERSION_CRANE }}
       - name: Login to quay.io
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         env:

--- a/.github/workflows/reusable-container-image-scan.yml
+++ b/.github/workflows/reusable-container-image-scan.yml
@@ -1,4 +1,6 @@
 name: Reusable container image scan
+env:
+  VERSION_CRANE: v0.16.1
 on:
   workflow_call:
     inputs:
@@ -41,6 +43,8 @@ jobs:
           go-version: stable
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
+        with:
+          version: ${{ env.VERSION_CRANE }}
       - name: quay crane login
         env:
           quay-robot-token: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,4 +1,6 @@
 name: Reusable Docker build
+env:
+  VERSION_CRANE: v0.16.1
 on:
   workflow_call:
     inputs:
@@ -108,6 +110,8 @@ jobs:
           check-latest: true
       - uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
+        with:
+          version: ${{ env.VERSION_CRANE }}
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -1,4 +1,6 @@
 name: Reusable Ko build
+env:
+  VERSION_CRANE: v0.16.1
 on:
   workflow_call:
     inputs:
@@ -88,6 +90,8 @@ jobs:
           cache-dependency-path: go.sum
           check-latest: true
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
+        with:
+          version: ${{ env.VERSION_CRANE }}
       - uses: GeoNet/setup-ko@f3c6980bb213dc8bb4856f52598a9230d910d06f # main
       - name: get session name
         id: get-session-name


### PR DESCRIPTION
update when ready.
A new release was cut today without assets due to a error with the release lifecycle tools of go-containerregistry.
Use the latest known working version