### PR TITLE
chore: make timeout-mins not required

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -88,7 +88,7 @@ on:
       timeout-mins:
         type: number
         description: 'minutes before build will timeout'
-        required: true
+        required: false
         default: 30
       setup:
         type: string


### PR DESCRIPTION
specify only when needed