### PR TITLE
fix: pin golangci-lint to latest master hash

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           eval '${{ inputs.setup }}'
       - name: golangci-lint
-        uses: GeoNet/golangci-lint-action@4cb96975783006316142911dac808e71dd8b0b40 # master
+        uses: GeoNet/golangci-lint-action@f76d5e859fe0815b3ba71fc6c45066932309e9da # master
         with:
           version: v1.52.2
           args: --timeout 30m -E gosec


### PR DESCRIPTION
This is needed as part of synching the local forked copy with its upstream master branch (would possibly handled by dependabot)