### PR TITLE
fix: bump golangci-lint to 1.54.2

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -38,5 +38,5 @@ jobs:
       - name: golangci-lint
         uses: GeoNet/golangci-lint-action@f76d5e859fe0815b3ba71fc6c45066932309e9da # master
         with:
-          version: v1.52.2
+          version: v1.54.2
           args: --timeout 30m -E gosec


### PR DESCRIPTION
This is to make the tests also fail when travis finds a problem, its using the latest version