### PR TITLE
feat: add setup input to ko-build

### DIFF
--- a/.github/workflows/reusable-go-container-apps.yml
+++ b/.github/workflows/reusable-go-container-apps.yml
@@ -139,6 +139,11 @@ on:
         type: string
         description: |
           extra args to pass `go test`
+      buildSetup:
+        required: false
+        type: string
+        description: |
+          shell commands to setup the build environment
     secrets:
       GH_CI_USER_TOKEN:
         required: false
@@ -163,6 +168,7 @@ jobs:
       aws-role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
       aws-role-session-name: ${{ inputs.aws-role-session-name }}
       registryGhcrUsernameOverride: ${{ inputs.registryGhcrUsernameOverride }}
+      setup: ${{ inputs.buildSetup }}
   scan:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "release"]'), github.event_name) && inputs.containerScanningEnabled && startsWith(github.repository, 'GeoNet/') != false }}
     needs: build

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -59,6 +59,11 @@ on:
         default: false
         description: |
           sign image and attestations
+      setup:
+        required: false
+        type: string
+        description: |
+          shell commands to setup the build environment
     secrets:
       GH_CI_USER_TOKEN:
         required: false
@@ -107,6 +112,9 @@ jobs:
         with:
           version: ${{ env.VERSION_CRANE }}
       - uses: GeoNet/setup-ko@f3c6980bb213dc8bb4856f52598a9230d910d06f # main
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - name: get session name
         id: get-session-name
         if: ${{ inputs.aws-region != '' && inputs.aws-role-arn-to-assume != '' && inputs.aws-role-duration-seconds != '' && inputs.registryOverride != '' }}

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ jobs:
     #   aws-region: ap-southeast-2
     #   aws-role-arn-to-assume: arn:aws:iam::ACCOUNT_ID:role/github-actions-ROLE_NAME
     #   aws-role-duration-seconds: "3600"
+    #   setup: |
+    #     sudo apt install -y something-needed-for-build
 ```
 
 - dynamic build of images based on entrypoints (where there is a `package main`), unless if _inputs.paths_ is set
@@ -862,6 +864,8 @@ jobs:
     #   aws-region: ap-southeast-2
     #   aws-role-arn-to-assume: arn:aws:iam::$ACCOUNT:role/$ROLE_NAME
     #   aws-role-duration-seconds: "3600"
+    #   buildSetup: |
+    #     sudo apt install -y something-needed-for-build
 ```
 
 for configuration see [`on.workflow_call.inputs` in .github/workflows/reusable-go-container-apps.yml](.github/workflows/reusable-go-container-apps.yml).


### PR DESCRIPTION
add a setup string input for executing arbitrary commands to initialise a build environment, through things like installing packages.

a Ko build is pretty much just Go build with extra container wrapper-y bits, so they inherit the same build properties from their host