### PR TITLE
fix: use expressed docker run for shell check

### DIFF
--- a/.github/workflows/reusable-bash-shellcheck.yml
+++ b/.github/workflows/reusable-bash-shellcheck.yml
@@ -23,7 +23,64 @@ jobs:
           echo "scripts=${all_shell_scripts[@]}" >> $GITHUB_OUTPUT
       - id: shellcheck
         if: ${{ steps.run-info.outputs.scripts }}
-        uses: docker://docker.io/koalaman/shellcheck-alpine:v0.9.0
-        with:
-          entrypoint: shellcheck
-          args: --external-sources --exclude=2230 --color=auto ${{ steps.run-info.outputs.scripts }}
+        run: |
+          docker run \
+            -e "ACTIONS_CACHE_URL" \
+            -e "ACTIONS_RUNTIME_TOKEN" \
+            -e "ACTIONS_RUNTIME_URL" \
+            -e "GITHUB_ACTION" \
+            -e "GITHUB_ACTION_REF" \
+            -e "GITHUB_ACTION_REPOSITORY" \
+            -e "GITHUB_ACTOR" \
+            -e "GITHUB_ACTOR_ID" \
+            -e "GITHUB_API_URL" \
+            -e "GITHUB_BASE_REF" \
+            -e "GITHUB_ENV" \
+            -e "GITHUB_EVENT_NAME" \
+            -e "GITHUB_EVENT_PATH" \
+            -e "GITHUB_GRAPHQL_URL" \
+            -e "GITHUB_HEAD_REF" \
+            -e "GITHUB_JOB" \
+            -e "GITHUB_OUTPUT" \
+            -e "GITHUB_PATH" \
+            -e "GITHUB_REF" \
+            -e "GITHUB_REF_NAME" \
+            -e "GITHUB_REF_PROTECTED" \
+            -e "GITHUB_REF_TYPE" \
+            -e "GITHUB_REPOSITORY" \
+            -e "GITHUB_REPOSITORY_ID" \
+            -e "GITHUB_REPOSITORY_OWNER" \
+            -e "GITHUB_REPOSITORY_OWNER_ID" \
+            -e "GITHUB_RETENTION_DAYS" \
+            -e "GITHUB_RUN_ATTEMPT" \
+            -e "GITHUB_RUN_ID" \
+            -e "GITHUB_RUN_NUMBER" \
+            -e "GITHUB_SERVER_URL" \
+            -e "GITHUB_SHA" \
+            -e "GITHUB_STATE" \
+            -e "GITHUB_STEP_SUMMARY" \
+            -e "GITHUB_TRIGGERING_ACTOR" \
+            -e "GITHUB_WORKFLOW" \
+            -e "GITHUB_WORKFLOW_REF" \
+            -e "GITHUB_WORKFLOW_SHA" \
+            -e "GITHUB_WORKSPACE" \
+            -e "HOME" \
+            -e "INPUT_ARGS" \
+            -e "RUNNER_ARCH" \
+            -e "RUNNER_ENVIRONMENT" \
+            -e "RUNNER_NAME" \
+            -e "RUNNER_OS" \
+            -e "RUNNER_TEMP" \
+            -e "RUNNER_TOOL_CACHE" \
+            -e "RUNNER_WORKSPACE" \
+            -e CI=true \
+            -e GITHUB_ACTIONS=true \
+            -e GITHUB_EVENT_PATH=/github/workflow/event.json \
+            -v "$PWD":"/github/workspace" \
+            -v "/home/runner/work/_temp/_github_home":"/github/home" \
+            -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" \
+            -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" \
+            --workdir /github/workspace \
+            --entrypoint shellcheck \
+            ghcr.io/geonet/base-images/shellcheck:v0.9.0 \
+            --external-sources --exclude=2230 --color=auto ${{ steps.run-info.outputs.scripts }}


### PR DESCRIPTION
the "uses: docker://" feature is broken in the org for some reason. just write it out as docker run for now. There's still some hidden GitHub magic which is given through "uses: docker://"

depends on: https://github.com/GeoNet/base-images/pull/84