### PR TITLE
chore: separate docker build and push for test

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -159,6 +159,9 @@ jobs:
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - name: validate
         env:
           CONTEXT: ${{ inputs.context }}
@@ -219,9 +222,6 @@ jobs:
           if [ "$FAIL" = true ]; then
             exit 1
           fi
-      - name: setup
-        run: |
-          eval '${{ inputs.setup }}'
       - id: run-info
         name: collect job run info
         env:
@@ -292,11 +292,12 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-path }}
           retention-days: 1
-      - name: Build and push
+      - name: Build
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         id: build
         with:
-          push: ${{ inputs.push }}
+          push: false
+          load: true
           tags: ${{ steps.run-info.outputs.images-with-tags }}
           context: ${{ inputs.context }}
           platforms: ${{ inputs.platforms }}
@@ -314,11 +315,27 @@ jobs:
           PUSH: ${{ inputs.push }}
         run: |
           eval '${{ inputs.test }}'
+      - name: Push
+        if: ${{ inputs.push == true }}
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        id: push
+        with:
+          push: ${{ inputs.push }}
+          tags: ${{ steps.run-info.outputs.images-with-tags }}
+          context: ${{ inputs.context }}
+          platforms: ${{ inputs.platforms }}
+          file: ${{ inputs.dockerfile }}
+          build-args: ${{ inputs.buildArgs }}
+          labels: |
+            org.opencontainers.image.name=${{ inputs.imageName }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+          target: ${{ inputs.target }}
       - name: get-digests
         id: get-digests
         if: ${{ inputs.push == true }}
         env:
-          DESTINATION: ${{ steps.run-info.outputs.image }}@${{ steps.build.outputs.digest }}
+          DESTINATION: ${{ steps.run-info.outputs.image }}@${{ steps.push.outputs.digest }}
         run: |
           DESTINATION_DIGEST="$(crane digest "${DESTINATION}" || true)"
           (
@@ -355,5 +372,7 @@ jobs:
       - name: image result
         if: ${{ inputs.push == true }}
         id: result
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
         run: |
-          echo -e "Built, pushed and signed:\n\n$(echo ${{ steps.image.outputs.image }} | sed 's/,/\n/g' | sed 's/^/- /g')"
+          echo -e "Built, pushed and signed:\n\n$(echo "$IMAGE" | sed 's/,/\n/g' | sed 's/^/- /g')"


### PR DESCRIPTION
build image in local docker before test and push.

prevents pulling image using existing tag which overrides image, instead uses locally built image in test.

fixes behaviour in: https://github.com/GeoNet/docker-gamit-base/actions/runs/6332302931/job/17198621752#step:21:12

also fixes order of setup and validate