### PR TITLE
chore: remove yq action

### DIFF
--- a/.github/workflows/presubmit-workflow-lint.yml
+++ b/.github/workflows/presubmit-workflow-lint.yml
@@ -50,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
       - name: check for run steps without name
         run: |
           FAILURES=false

--- a/.github/workflows/reusable-container-image-scan.yml
+++ b/.github/workflows/reusable-container-image-scan.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           exit 1
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
       - id: set
         name: require GeoNet org
         run: |

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -145,7 +145,6 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: stable
@@ -157,6 +156,8 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+        with:
+          image: ghcr.io/geonet/base-images/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: setup

--- a/.github/workflows/reusable-presubmit-actions-workflow-require-commit-digest-vet.yml
+++ b/.github/workflows/reusable-presubmit-actions-workflow-require-commit-digest-vet.yml
@@ -10,7 +10,6 @@ jobs:
         run: |
           exit 1
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
       - id: actions-per-workflow
         name: discover actions per workflow
         run: |


### PR DESCRIPTION
yq is pre-installed in linux actions runner-images

and use base-images/binfmt instead of docker.io hosted image. depends on https://github.com/GeoNet/base-images/pull/110