### PR TITLE
chore: disable spellcheck in policy-conformance

### DIFF
--- a/.github/workflows/reusable-policy-conformance.yml
+++ b/.github/workflows/reusable-policy-conformance.yml
@@ -15,7 +15,7 @@ on:
                   required: false
                   gitHubOrganization: GeoNet
                 spellcheck:
-                  locale: UK
+                  locale: kiwi
                 maximumOfOneCommit: false
                 header:
                   length: 89


### PR DESCRIPTION
disable spellcheck by using a non-existent locale _kiwi_.

We use kiwi English which is a combination between US and UK spelling.
Without modification, conform only supports either or.

it works! see: https://github.com/GeoNet/Actions/actions/runs/6488227007/job/17620216640?pr=206