### PR TITLE
chore: remove ghcr auth override push gate for ko

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -290,10 +290,10 @@ jobs:
         run: |
           aws ecr get-login-password --region ${{ inputs.aws-region }} | crane auth login ${{ inputs.registryOverride }} -u AWS --password-stdin
       - name: override login to ghcr
+        if: ${{ env.registryGhcrUsernameOverride != '' && env.registryGhcrPasswordOverride != '' }}
         env:
           registryGhcrUsernameOverride: ${{ inputs.registryGhcrUsernameOverride }}
           registryGhcrPasswordOverride: ${{ secrets.GH_CI_USER_TOKEN }}
-        if: ${{ env.registryGhcrUsernameOverride != '' && env.registryGhcrPasswordOverride != '' }}
         run: |
           echo "${{ env.registryGhcrPasswordOverride }}" | crane auth login ghcr.io -u ${{ env.registryGhcrUsernameOverride }} --password-stdin
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -154,10 +154,10 @@ jobs:
         run: |
           aws ecr get-login-password --region ${{ inputs.aws-region }} | crane auth login ${{ inputs.registryOverride }} -u AWS --password-stdin
       - name: override login to ghcr
+        if: ${{ env.registryGhcrUsernameOverride != '' && env.registryGhcrPasswordOverride != '' }}
         env:
           registryGhcrUsernameOverride: ${{ inputs.registryGhcrUsernameOverride }}
           registryGhcrPasswordOverride: ${{ secrets.GH_CI_USER_TOKEN }}
-        if: ${{ inputs.push == true && env.registryGhcrUsernameOverride != '' && env.registryGhcrPasswordOverride != '' }}
         run: |
           echo "${{ env.registryGhcrPasswordOverride }}" | crane auth login ghcr.io -u ${{ env.registryGhcrUsernameOverride }} --password-stdin
       - id: build


### PR DESCRIPTION
some builds need base images from other repos and need to special auth