### PR TITLE
chore: use dependabot semantic commit message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    commit-message:
+      prefix: "chore(deps)"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
use an allowed commit prefix

attempts to resolve: https://github.com/GeoNet/base-images/pull/125

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message