### PR TITLE
fix: make dependabot create conform compatible PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore: "
     schedule:
       interval: "weekly"


### PR DESCRIPTION
currently the formatting doesn't meet conform standards

from the [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message): ... This means that, for example, if you end the prefix with a whitespace, there will be no colon added ...