### PR TITLE
feat: add scripted actions updates

### DIFF
--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -15,7 +15,7 @@ jobs:
         exit 1
   sync-forks:
     env:
-      FORKS: '("mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint")'
+      FORKS: '( "mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint" )'
     runs-on: ubuntu-latest
     steps:
       - name: configure system

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -22,22 +22,8 @@ jobs:
         run: |
           gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           gh auth status
-      - name: determine changes
-        id: determine-changes
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: run sync
+        id: run-sync
         run: |
-          set -x
-          for FORK in "${!FORKS[@]}";
-          do
-          printf "fork:%s\n" ${FORKS[$FORK]}
-            BRANCH=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${FORKS[$FORK]} | jq -rc .default_branch)
-            echo "${BRANCH}"
-            gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${FORKS[$FORK]}/merge-upstream" \
-            -f branch="${BRANCH}"
-          done
+          ./hack/sync-forks.sh

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -15,7 +15,7 @@ jobs:
         exit 1
   sync-forks:
     env:
-      FORKS: ("mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint")
+      FORKS: '("mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint")'
     runs-on: ubuntu-latest
     steps:
       - name: configure system
@@ -28,6 +28,7 @@ jobs:
           set +x
           for FORK in "${!FORKS[@]}";
           do
+          printf "fork:%s\n" ${FORKS[$FORK]}
             BRANCH=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -15,7 +15,7 @@ jobs:
         exit 1
   sync-forks:
     env:
-      FORKS: '( "mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint" )'
+      FORKS: '"mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint"'
     runs-on: ubuntu-latest
     steps:
       - name: configure system

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -25,6 +25,7 @@ jobs:
       - name: determine changes
         id: determine-changes
         run: |
+          set +x
           for FORK in "${!FORKS[@]}";
           do
             BRANCH=$(gh api \

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -1,12 +1,14 @@
 name: sync actions forks
 on:
+  push:
+    branches: sync-forks
   schedule:
     - cron: 0 1 * * *
   workflow_dispatch: {}
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.repository, 'GeoNet/') == false }}
+    if: ${{ startsWith(github.repository, 'mountainmoss/') == false }}
     steps:
     - name: require GeoNet org
       run: |

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: determine changes
         id: determine-changes
         run: |
-          set +x
+          set -x
           for FORK in "${!FORKS[@]}";
           do
           printf "fork:%s\n" ${FORKS[$FORK]}
@@ -33,11 +33,11 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${FORKS[$FORK]} | jq -rc .default_branch)
-
+            echo "${BRANCH}"
             gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${FORKS[$FORK]}/merge-upstream \
+            "/repos/${FORKS[$FORK]}/merge-upstream" \
             -f branch="${BRANCH}"
           done

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -15,13 +15,11 @@ jobs:
         exit 1
   sync-forks:
     env:
-      FORKS: (GeoNet/setup-ko GeoNet/setup-crane GeoNet/chainguard-dev-actions GeoNet/golangci-lint-action GeoNet/conform-actions GeoNet/chainguard-images-actions GeoNet/terraform-linters-setup-tflint)
+      FORKS: (mountainmoss/setup-ko mountainmoss/setup-crane mountainmoss/chainguard-dev-actions mountainmoss/golangci-lint-action mountainmoss/conform-actions mountainmoss/chainguard-images-actions mountainmoss/terraform-linters-setup-tflint)
     runs-on: ubuntu-latest
     steps:
       - name: configure system
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
           gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           gh auth status
       - name: determine changes

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -32,12 +32,12 @@ jobs:
             BRANCH=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${FORK} | jq -rc .default_branch)
+            /repos/${FORKS[$FORK]} | jq -rc .default_branch)
 
             gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/OWNER/REPO/merge-upstream \
+            /repos/${FORKS[$FORK]}/merge-upstream \
             -f branch="${BRANCH}"
           done

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -1,0 +1,41 @@
+name: sync actions forks
+on:
+  schedule:
+    - cron: 0 1 * * *
+  workflow_dispatch: {}
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.repository, 'GeoNet/') == false }}
+    steps:
+    - name: require GeoNet org
+      run: |
+        exit 1
+  sync-forks:
+    env:
+      FORKS: (GeoNet/setup-ko GeoNet/setup-crane GeoNet/chainguard-dev-actions GeoNet/golangci-lint-action GeoNet/conform-actions GeoNet/chainguard-images-actions GeoNet/terraform-linters-setup-tflint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: configure system
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
+          gh auth status
+      - name: determine changes
+        id: determine-changes
+        run: |
+          for FORK in "${!FORKS[@]}";
+          do
+            BRANCH=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${FORK} | jq -rc .default_branch)
+
+            gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/OWNER/REPO/merge-upstream \
+            -f branch="${BRANCH}"
+          done

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -15,7 +15,7 @@ jobs:
         exit 1
   sync-forks:
     env:
-      FORKS: (mountainmoss/setup-ko mountainmoss/setup-crane mountainmoss/chainguard-dev-actions mountainmoss/golangci-lint-action mountainmoss/conform-actions mountainmoss/chainguard-images-actions mountainmoss/terraform-linters-setup-tflint)
+      FORKS: ("mountainmoss/setup-ko" "mountainmoss/setup-crane" "mountainmoss/chainguard-dev-actions" "mountainmoss/golangci-lint-action" "mountainmoss/conform-actions" "mountainmoss/chainguard-images-actions" "mountainmoss/terraform-linters-setup-tflint")
     runs-on: ubuntu-latest
     steps:
       - name: configure system

--- a/hack/sync-forks.sh
+++ b/hack/sync-forks.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+for FORK in "${!FORKS[@]}";
+do
+    printf "fork: %s\n" ${FORKS[$FORK]}
+    BRANCH=$(gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/${FORKS[$FORK]} | jq -rc .default_branch)
+    printf "branch: %s\n" ${BRANCH}
+    gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/${FORKS[$FORK]}/merge-upstream" \
+    -f branch="${BRANCH}"
+done


### PR DESCRIPTION
requires tweaking branch protection rules
api docs https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#sync-a-fork-branch-with-the-upstream-repository
we'll need to allow the github actions bot to force push these repos (github-actions[bot]@users.noreply.github.com)
- GeoNet/setup-ko
- GeoNet/setup-crane
- GeoNet/chainguard-dev-actions
- GeoNet/golangci-lint-action
- GeoNet/conform-actions
- GeoNet/chainguard-images-actions
- GeoNet/terraform-linters-setup-tflint

list from this api
`gh api --paginate  -H "Accept: application/vnd.github+json"   -H "X-GitHub-Api-Version: 2022-11-28"   '/orgs/GeoNet/repos?type=fork' | jq -r '.[].full_name`