### PR TITLE
feat: allow ability to set working directory of go app

### DIFF
--- a/.github/workflows/reusable-go-apps.yml
+++ b/.github/workflows/reusable-go-apps.yml
@@ -23,32 +23,49 @@ on:
         type: string
         description: |
           extra args to pass `go test`
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory of the application
 jobs:
   go-build:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-build-smoke-test.yml@main
     with:
       paths: ${{ inputs.paths }}
+      working-directory: ${{ inputs.working-directory }}
   gofmt:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-gofmt.yml@main
+    with:
+      working-directory: ${{ inputs.working-directory }}
   golangci-lint:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-golangci-lint.yml@main
     with:
       setup: ${{ inputs.golangciSetup }}
+      working-directory: ${{ inputs.working-directory }}
   go-test:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
     with:
       setup: ${{ inputs.testSetup }}
       extraArgs: ${{ inputs.goTestExtraArgs }}
+      working-directory: ${{ inputs.working-directory }}
   go-vet:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-vet.yml@main
+    with:
+      working-directory: ${{ inputs.working-directory }}
   govulncheck:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-govulncheck.yml@main
+    with:
+      working-directory: ${{ inputs.working-directory }}
   goimports:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-goimports.yml@main
+    with:
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -16,6 +16,7 @@ on:
       working-directory:
         required: false
         type: string
+        default: '.'
         description: |
           the working directory to run the build
 jobs:
@@ -29,8 +30,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - id: run-info
         name: collect job run info

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -12,9 +12,17 @@ on:
         type: string
         description: |
           extra args to pass `go test`
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory of the application
 jobs:
   go-test:
     runs-on: ubuntu-latest
+    env:
+      WORK_DIR: ${{ inputs.working-directory }}
     steps:
       - if: ${{ startsWith(github.repository, 'GeoNet/') == false }}
         name: require GeoNet org
@@ -23,8 +31,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - name: setup
         run: |
@@ -34,11 +42,11 @@ jobs:
         env:
           EXTRA_ARGS: ${{ inputs.extraArgs }}
         run: |
-          go test $EXTRA_ARGS -v -coverprofile /tmp/coverage.out -cover ./...
+          go test -C $WORK_DIR $EXTRA_ARGS -v -coverprofile /tmp/coverage.out -cover ./...
       - name: create coverage html
         id: coverage-html
         run: |
-          go tool cover -html=/tmp/coverage.out -o /tmp/coverage.html
+          go tool -C $WORK_DIR cover -html=/tmp/coverage.out -o /tmp/coverage.html
       - name: Upload test log
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         if: always()

--- a/.github/workflows/reusable-go-vet.yml
+++ b/.github/workflows/reusable-go-vet.yml
@@ -1,6 +1,13 @@
 name: reusable go vet
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory of the application
 jobs:
   go-vet:
     runs-on: ubuntu-latest
@@ -12,9 +19,11 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - name: vet
         id: vet
-        run: go vet -v ./...
+        env:
+          WORK_DIR: ${{ inputs.working-directory }}
+        run: go vet -C $WORK_DIR -v ./...

--- a/.github/workflows/reusable-gofmt.yml
+++ b/.github/workflows/reusable-gofmt.yml
@@ -1,6 +1,13 @@
 name: reusable gofmt
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory to run the step
 jobs:
   go-fmt:
     runs-on: ubuntu-latest
@@ -12,8 +19,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - name: gofmt
         id: gofmt

--- a/.github/workflows/reusable-goimports.yml
+++ b/.github/workflows/reusable-goimports.yml
@@ -1,6 +1,13 @@
 name: reusable goimports
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory of the application
 jobs:
   goimports:
     runs-on: ubuntu-latest
@@ -12,14 +19,16 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - name: goimports
         id: goimports
+        env:
+          WORK_DIR: ${{ inputs.working-directory }}
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
-          find . -type f -name '*.go' -not -path './vendor/*' | xargs -I{} goimports -w {}
+          find $WORK_DIR -type f -name '*.go' -not -path "${WORK_DIR}/vendor/*" | xargs -I{} goimports -w {}
       - name: determine changes
         id: determine-changes
         run: |

--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -13,6 +13,12 @@ on:
         type: string
         description: |
           shell commands to setup the test environment
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory of the application
 jobs:
   golangci:
     name: lint
@@ -25,8 +31,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - name: write .golangci.yml
         if: ${{ inputs.config }}
@@ -41,3 +47,4 @@ jobs:
         with:
           version: v1.55.1
           args: --timeout 30m -E gosec
+          working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/reusable-govulncheck.yml
+++ b/.github/workflows/reusable-govulncheck.yml
@@ -1,6 +1,13 @@
 name: reusable govulncheck
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: |
+          the working directory of the application
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
@@ -12,11 +19,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: ${{ inputs.working-directory }}/go.mod
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
           check-latest: true
       - name: govulncheck
         id: govulncheck
+        env:
+          WORK_DIR: ${{ inputs.working-directory }}
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          govulncheck -C $WORK_DIR ./...


### PR DESCRIPTION
Allows use of hybrid repos where the go application may be in a different directory from the project root.

Main idea is the introduction of a `working-directory` input, which has a default value of `.`. This default value results in the same behaviour as currently seen, that is, the go application is in the project root.

This `working-directory` can be changed and passed through to the relevant reusable workflows, and utilities.

The `working-directory` functionality is based on `golangci-lint-action` functionality (https://github.com/golangci/golangci-lint-action/tree/3cfe3a4abbb849e10058ce4af15d205b6da42804?tab=readme-ov-file#how-to-use)

Rationale: some repos have a monorepo structure, containing several projects of mixed languages (for example the `docker-gamit` repo, with a golang applications and bash applications). The ability to specify `worker-directory` for golang-specific workflows, allows for a monorepo structure like the following:
```
docker-gamit
    - go-app
    - bash-scripts
```
Layouts like this ensure that one project (say, `bash-scripts` containing `.`-prefixed application files), are _not_ treated as part of a go application, and vice versa.
   