### PR TITLE
chore: upgrade to go version 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/GeoNet/Actions
 
-go 1.20
+go 1.21


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/13645