### PR TITLE
feat: allow setup for go-vet, govulncheck, and go-build

### DIFF
--- a/.github/workflows/reusable-go-apps.yml
+++ b/.github/workflows/reusable-go-apps.yml
@@ -8,16 +8,16 @@ on:
         description: |
           the Go entrypoint paths for applications, where there they have `package main`
           e.g: ./cmd/thing1 ./cmd/thing2
+      buildSetup:
+        type: string
+        required: false
+        description: |
+          shell commands to setup the build environment
       testSetup:
         type: string
         required: false
         description: |
           shell commands to setup the test environment
-      golangciSetup:
-        type: string
-        required: false
-        description: |
-          shell commands to setup the golangci-lint environment
       goTestExtraArgs:
         required: false
         type: string
@@ -28,6 +28,7 @@ jobs:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-build-smoke-test.yml@main
     with:
+      setup: ${{ inputs.buildSetup }}
       paths: ${{ inputs.paths }}
   gofmt:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
@@ -36,7 +37,7 @@ jobs:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-golangci-lint.yml@main
     with:
-      setup: ${{ inputs.golangciSetup }}
+      setup: ${{ inputs.buildSetup }}
   go-test:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
@@ -46,9 +47,13 @@ jobs:
   go-vet:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-vet.yml@main
+    with:
+      setup: ${{ inputs.buildSetup }}
   govulncheck:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-govulncheck.yml@main
+    with:
+      setup: ${{ inputs.buildSetup }}
   goimports:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-goimports.yml@main

--- a/.github/workflows/reusable-go-apps.yml
+++ b/.github/workflows/reusable-go-apps.yml
@@ -42,7 +42,7 @@ jobs:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
     with:
-      setup: ${{ inputs.testSetup }}
+      setup: ${{ inputs.testSetup || inputs.buildSetup }}
       extraArgs: ${{ inputs.goTestExtraArgs }}
   go-vet:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}

--- a/.github/workflows/reusable-go-vet.yml
+++ b/.github/workflows/reusable-go-vet.yml
@@ -1,6 +1,12 @@
 name: reusable go vet
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      setup:
+        type: string
+        required: false
+        description: |
+          shell commands to setup the go-vet environment
 jobs:
   go-vet:
     runs-on: ubuntu-latest
@@ -15,6 +21,9 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
           check-latest: true
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - name: vet
         id: vet
         run: go vet -v ./...

--- a/.github/workflows/reusable-govulncheck.yml
+++ b/.github/workflows/reusable-govulncheck.yml
@@ -1,6 +1,12 @@
 name: reusable govulncheck
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      setup:
+        type: string
+        required: false
+        description: |
+          shell commands to setup the govulncheck environment
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
@@ -15,6 +21,9 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
           check-latest: true
+      - name: setup
+        run: |
+          eval '${{ inputs.setup }}'
       - name: govulncheck
         id: govulncheck
         run: |


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/15422

In doing the above ticket^, I have found the `reusable-go-apps` workflow not very reusable at all. This change will align it more closely with its name.

Tested here, works: https://github.com/GeoNet/4D-Ashfall/actions/runs/9120866234/job/25079049471