### PR TITLE
feat: allow use of consistent container tagging

### DIFF
--- a/.github/actions/tagging/action.yml
+++ b/.github/actions/tagging/action.yml
@@ -1,0 +1,28 @@
+name: Tagging
+description: Consistent and unique container tagging, suitable for immutable tagging
+outputs:
+  relevant-sha:
+    description: |
+      Short commit sha based on last commit of pull request, or the last merge commit
+    value: ${{ steps.tags.outputs.relevant-sha }}
+  timestamp:
+    description: |
+      UTC time of when this action was run
+    value: ${{ steps.tags.outputs.timestamp }}
+  tag:
+    description: |
+      Recommended container tag, using commit sha and timestamp
+    value:
+      ${{ format('{0}-git{1}', steps.tags.outputs.timestamp, steps.tags.outputs.relevant-sha) }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate tags
+      id: tags
+      env:
+        RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      shell: bash
+      run: |
+        echo "relevant-sha=$(git rev-parse --short $RELEVANT_SHA)" >> $GITHUB_OUTPUT
+        echo "timestamp=$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
     - [Markdown lint](#markdown-lint)
     - [Copy to S3](#copy-to-s3)
     - [Clean container versions](#clean-container-versions)
+  - [Composite Actions](#composite-actions)
+    - [Tagging](#tagging)
   - [Other documentation](#other-documentation)
     - [Dependabot and Actions workflow imports](#dependabot-and-actions-workflow-imports)
     - [Versioning for container images](#versioning-for-container-images)
@@ -1088,6 +1090,35 @@ jobs:
       package-name: base-images/fedora
       ignored-regex: '(stable)|(38)'
       number-kept: 7
+```
+
+## Composite Actions
+
+### Tagging
+
+STATUS: stable
+
+Generic container tagging.
+
+Generally will be used in the reusable workflows, but if one needed to use the action directly:
+
+```yaml
+on: [push]
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: steps.tagging.outputs.tag
+    steps:
+      - uses: actions/checkout@v4
+      - id: tagging
+        uses: GeoNet/Actions/.github/actions/tagging@main
+  build:
+    needs: prepare
+    uses: GeoNet/Actions/.github/workflows/reusable-docker-build.yml@main
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
 ```
 
 ## Other documentation


### PR DESCRIPTION
Motivating ticket: https://github.com/GeoNet/tickets/issues/14398

This PR adds a composite action providing a consistent tag, or at least, consistent outputs to construct such a tag.
This should be suitable for use in the reusable workflows, as well as explicitly within users own workflow jobs.

Currently, the proposed format is commit sha-timestamp-build id...for example, `1da9c71-20240515111413-9094587538`

Points to consider are:
- order of fields
- need for timestamp (which was part of my original work to better ensure "uniqueness", but may not be required in presence of build id
- any other missing fields

