### PR TITLE
feat: add default session time

### DIFF
--- a/.github/workflows/reusable-copy-to-s3.yml
+++ b/.github/workflows/reusable-copy-to-s3.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: 3600
         description: |
-          the amount of seconds to hold a session open for.
+          the number of seconds to hold a session open for.
       aws-role-session-name:
         type: string
         required: false

--- a/.github/workflows/reusable-copy-to-s3.yml
+++ b/.github/workflows/reusable-copy-to-s3.yml
@@ -16,7 +16,8 @@ on:
           e.g: arn:aws:iam::ACCOUNT_ID:role/github-actions-ROLE_NAME
       aws-role-duration-seconds:
         type: string
-        required: true
+        required: false
+        default: 3600
         description: |
           the amount of seconds to hold a session open for.
       aws-role-session-name:


### PR DESCRIPTION
Adds a default value of `3600` to `aws-role-duration-seconds`, making it consistent with defaults for the docker build, ko build, and go container build workflows.