### PR TITLE
feat: add single file copy mode

### DIFF
--- a/.github/workflows/reusable-copy-to-s3.yml
+++ b/.github/workflows/reusable-copy-to-s3.yml
@@ -30,6 +30,12 @@ on:
         required: false
         description: |
           the command to use, whether cp (copy) or sync
+      single-file:
+        type: boolean
+        default: false
+        required: false
+        description: |
+          single file copy (only for `cp`, no effect for `sync`)
       direction:
         type: string
         default: to
@@ -119,7 +125,9 @@ jobs:
           ARGS=()
           case "$CP_OR_SYNC" in
             cp)
-              ARGS+=(--recursive)
+              if [ ${{ inputs.single-file }} = false ]; then
+                ARGS+=(--recursive)
+              fi
             ;;
             sync)
 


### PR DESCRIPTION
Adds ability to copy a single file to or from s3.

See https://github.com/GeoNet/docker-bnc/actions/runs/9513165236 for new feature in action, as well as a test that the current `cp` still works as current