### PR TITLE
fix: add missing deployment type rule

### DIFF
--- a/.github/workflows/reusable-aws-deploy.yml
+++ b/.github/workflows/reusable-aws-deploy.yml
@@ -93,6 +93,7 @@ jobs:
           cluster: ${{ inputs.deployment-type == 'ecs' && inputs.cluster || '' }}
           wait-for-service-stability: true
       - name: Update EventBridge target
+        if: inputs.deployment-type == 'eventbridge'
         run: |
           # get target
           aws events list-targets-by-rule \


### PR DESCRIPTION
Tries to deploy EventBridge rule event if it's ECS deployment