### PR TITLE
feat: allow go test results to upload to s3.

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -2,6 +2,17 @@ name: reusable go test
 on:
   workflow_call:
     inputs:
+      aws-role-arn-to-assume:
+        type: string
+        required: false
+        description: |
+          role to use to upload test results to s3 bucket,
+          see reusable-copy-to-s3 workflow for more detail.
+      s3-bucket:
+        type: string
+        required: false
+        description: |
+          the AWS S3 bucket name to upload test results to.
       setup:
         required: false
         type: string
@@ -49,3 +60,14 @@ jobs:
             /tmp/coverage.html
           if-no-files-found: error
           retention-days: 1
+  go-test-upload:
+    needs: go-test
+    if: ${{ inputs.aws-role-arn-to-assume && inputs.s3-bucket }}
+    uses: GeoNet/Actions/.github/workflows/reusable-copy-to-s3.yml@main
+    with:
+      aws-role-arn-to-assume: ${{ inputs.aws-role-arn-to-assume }}
+      artifact-name: test-results
+      artifact-path: ./coverage
+      s3-bucket: s3://${{inputs.s3-bucket}}/test-coverage-results/${{github.repository}}/go/
+      cp-or-sync: cp
+      direction: to

--- a/README.md
+++ b/README.md
@@ -605,9 +605,13 @@ on:
 jobs:
   go-test:
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
+    with:
+      aws-role-arn-to-assume: github-to-s3-upload-role
+      s3-bucket: my-bucket
 ```
 
 test coverage results upload to job artifacts, found at the bottom of a job summary page.
+An optional bucket and role can be provided to upload the results to S3 as well.
 
 ### Go vulnerability check
 


### PR DESCRIPTION
Optional behaviour, provided an s3 role and bucket name are provided.

Tried here successfully: https://github.com/GeoNet/geocodenz/actions/runs/10257082014/job/28377435623?pr=49