### PR TITLE
fix: simplify conventional commits

### DIFF
--- a/.github/workflows/reusable-policy-conformance.yml
+++ b/.github/workflows/reusable-policy-conformance.yml
@@ -26,16 +26,9 @@ on:
                   required: true
                 conventional:
                   types:
-                    - chore
-                    - ci
-                    - docs
                     - feat
                     - fix
-                    - refactor
-                    - release
-                    - revert
-                    - style
-                    - test
+                    - nfc
                   scopes: [".*"]
 jobs:
   conform:

--- a/README.md
+++ b/README.md
@@ -719,13 +719,9 @@ policies:
       required: true
     conventional:
       types:
-        - chore
-        - docs
-        - perf
-        - refactor
-        - style
-        - test
-        - release
+        - feat
+        - fix
+        - nfc
       scopes: [".*"]
 ```
 


### PR DESCRIPTION
Our conventional commits are all over the place. Everyone uses different commit types and there are too many types that overlap. This significantly reduces the usefulness of conventional commits.

This PR aims to address this by radically simplifying the conventional commits to use three types:

## feat:

New stuff, features.

## fix:

Fixing broken stuff, correcting stuff, small improvements etc.

## nfc:

Non-functional-change. Documentation, code comments, refactoring, style changes etc. Stuff that doesnt DO anything.
NFC changes are easy to review.


It's much easier to pick one of these three categories for your commits than picking between the 10 types we have now.
I've used this format in a previous job and it works well.