### PR TITLE
feat: add deployment summary

### DIFF
--- a/.github/workflows/reusable-aws-deploy.yml
+++ b/.github/workflows/reusable-aws-deploy.yml
@@ -114,3 +114,7 @@ jobs:
             --name ${{ inputs.deployment-tag-param-name }} \
             --value $(jq -cn --arg image-tag $IMAGE_TAG --arg task-arn ${{ steps.task-deploy.outputs.task-definition-arn }} '$ARGS.named') \
             --overwrite
+      - name: Summary - deployment build
+        run: |
+          echo "Task revision created: ${{ steps.task-deploy.outputs.task-definition-arn }}"
+          echo "Image URI: ${{ inputs.image }}"


### PR DESCRIPTION
Add deployment summary to build logs, useful for when AWS ParamStore not being used.

Example output:
```
Task revision created: arn:aws:ecs:ap-southeast-2:615890063537:task-definition/tf-dev-gloria-ng-rinex-igs-service:48
Image URI: 615890063537.dkr.ecr.ap-southeast-2.amazonaws.com/gloria-ng-worker:20240808073759-git35bfa39
```