### PR TITLE
fix: bump node version in reuseable-eslint

### DIFF
--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: "20.x"
+          node-version: "21.x"
       - name: Install Node modules
         id: install-node-modules
         env:


### PR DESCRIPTION
From 20.x to 21.x