### PR TITLE
fix: migrate to artifacts v4

### DIFF
--- a/.github/workflows/reusable-copy-to-s3.yml
+++ b/.github/workflows/reusable-copy-to-s3.yml
@@ -104,7 +104,7 @@ jobs:
           if [ "$ERRORS" = true ]; then
             exit 1
           fi
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         if: ${{ inputs.direction == 'to' }}
         with:
           name: ${{ inputs.artifact-name }}
@@ -153,9 +153,10 @@ jobs:
               echo "*ghostly oooooohhh*"
           esac
           aws s3 "$CP_OR_SYNC" "${ARGS[@]}"
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: ${{ inputs.direction == 'from' }}
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-path }}
           retention-days: 1
+          overwrite: true

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -310,7 +310,7 @@ jobs:
           registryGhcrPasswordOverride: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
           echo "${{ env.registryGhcrPasswordOverride }}" | crane auth login ghcr.io -u ${{ env.registryGhcrUsernameOverride }} --password-stdin
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         if: ${{ inputs.artifact-name != '' && inputs.artifact-path != '' }}
         with:
           name: ${{ inputs.artifact-name }}
@@ -374,7 +374,7 @@ jobs:
           echo "image=$IMAGE_URI" >> $GITHUB_OUTPUT
           echo $IMAGE_URI > imageinfo_${{ inputs.imageName}}${{ github.run_id }}${{ github.run_attempt }}.txt
       - name: Upload imageinfo
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: ${{ inputs.imageName }}${{ github.run_id }}${{ github.run_attempt }}
           path: imageinfo_${{ inputs.imageName }}${{ github.run_id }}${{ github.run_attempt }}.txt

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           go tool cover -html=/tmp/coverage.out -o /tmp/coverage.html
       - name: Upload test log
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: always()
         with:
           name: test-results
@@ -49,3 +49,4 @@ jobs:
             /tmp/coverage.html
           if-no-files-found: error
           retention-days: 1
+          overwrite: true


### PR DESCRIPTION
This PR migrates reusable workflows from upload/download artifacts v3 to v4.
v4 represents breaking changes: https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#compatibility
To summarise:
- no longer upload the same named artifact more than once (PR fix: uses `overwrite: true` to maintain current behaviour)
- can only use download v4 to access artifacts uploaded with v4 (from code search, appears to be no case of a workflow using v3 to download an artifact produced by the reusables)

This PR should maintain current behaviour, and not break any existing workflows.