### PR TITLE
Revert "feat: allow go test results to upload to s3"

### DIFF
--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -2,17 +2,6 @@ name: reusable go test
 on:
   workflow_call:
     inputs:
-      aws-role-arn-to-assume:
-        type: string
-        required: false
-        description: |
-          role to use to upload test results to s3 bucket,
-          see reusable-copy-to-s3 workflow for more detail.
-      s3-bucket:
-        type: string
-        required: false
-        description: |
-          the AWS S3 bucket name to upload test results to.
       setup:
         required: false
         type: string
@@ -60,14 +49,3 @@ jobs:
             /tmp/coverage.html
           if-no-files-found: error
           retention-days: 1
-  go-test-upload:
-    needs: go-test
-    if: ${{ inputs.aws-role-arn-to-assume && inputs.s3-bucket }}
-    uses: GeoNet/Actions/.github/workflows/reusable-copy-to-s3.yml@main
-    with:
-      aws-role-arn-to-assume: ${{ inputs.aws-role-arn-to-assume }}
-      artifact-name: test-results
-      artifact-path: ./coverage
-      s3-bucket: s3://${{inputs.s3-bucket}}/test-coverage-results/${{github.repository}}/go/
-      cp-or-sync: cp
-      direction: to

--- a/README.md
+++ b/README.md
@@ -605,13 +605,9 @@ on:
 jobs:
   go-test:
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
-    with:
-      aws-role-arn-to-assume: github-to-s3-upload-role
-      s3-bucket: my-bucket
 ```
 
 test coverage results upload to job artifacts, found at the bottom of a job summary page.
-An optional bucket and role can be provided to upload the results to S3 as well.
 
 ### Go vulnerability check
 


### PR DESCRIPTION
This reverts commit 209d96c097af2aea729f656a6735e88937a90e48. 

Was getting this error when using the action in go-reusable-app: exceed the limit on called workflow depth of 3