### PR TITLE
feat: update the golangci-lint action

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           eval '${{ inputs.setup }}'
       - name: golangci-lint
-        uses: GeoNet/golangci-lint-action@f76d5e859fe0815b3ba71fc6c45066932309e9da # master
+        uses: GeoNet/golangci-lint-action@1b9b0798df716be5ff7cebc26795b000939a4b41 # master
+        continue-on-error: true
         with:
-          version: v1.55.1
+          version: v1.63.4
           args: --timeout 30m -E gosec


### PR DESCRIPTION
This is required to allow linting of go 1.23 code and tools. It temporarily sets the action to be non-fatal to allow the repo code to catch up. Once this has happened the ignore line will be removed.