### PR TITLE
feat: allow eslint workflow to use specific node version (take 2)

### DIFF
--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -9,6 +9,15 @@ on:
           A list of root directory/s to where a package.json and eslint
           configuration file (eslint.config.mjs) exist.
           e.g.: my/root/one my/cool/root/two
+      node-version:
+        required: false
+        type: string
+        default: "21.x"
+        description: |
+          The version of Node to use when installing node modules and
+          running eslint.
+          See https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax
+          for syntax.
 jobs:
   eslint:
     runs-on: ubuntu-latest
@@ -20,7 +29,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: "21.x"
+          node-version: ${{ inputs.node-version }}
       - name: Install Node modules
         id: install-node-modules
         env:

--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,7 @@ jobs:
 
 ### ESLint
 
-STATUS: alpha
+STATUS: beta
 
 Used to run ESLint on one or more directories. The paths specified
 should have a package.json with eslint defined, alongside an eslint config
@@ -1111,6 +1111,7 @@ jobs:
       paths: |
         ./root/folder/one
         ./cool/root/folder/two
+      node-version: 22.x
 ```
 
 


### PR DESCRIPTION
Useful when upgrading node versions in an app that has strict engine requirements

(testing this will merge)