### PR TITLE
fix: confine linting to directory where eslint config file is

### DIFF
--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -44,5 +44,5 @@ jobs:
           PATHS: ${{ inputs.paths }}
         run: |
           for path in $PATHS; do
-            ESLINT_USE_FLAT_CONFIG=true $path/node_modules/.bin/eslint -c $path/eslint.config.mjs
+            ESLINT_USE_FLAT_CONFIG=true $path/node_modules/.bin/eslint -c $path/eslint.config.mjs $path
           done


### PR DESCRIPTION
This is ensures only JavaScript files in the directory that the eslint config file is are linted.

**Tested in Tilde:**

**Current failing:** https://github.com/GeoNet/tilde/actions/runs/12818154802/job/35742988801

**Using this branch, passing:**
https://github.com/GeoNet/tilde/actions/runs/12819085053/job/35745995955

**Using this branch, failing because of linting error:**
https://github.com/GeoNet/tilde/actions/runs/12819161652/job/35746254649