### PR TITLE
feat: allow go test results to upload to s3

### DIFF
--- a/.github/workflows/reusable-go-apps.yml
+++ b/.github/workflows/reusable-go-apps.yml
@@ -23,6 +23,16 @@ on:
         type: string
         description: |
           extra args to pass `go test`
+      test-coverage-upload-role:
+        type: string
+        required: false
+        description: |
+          the AWS IAM role to use to upload test results to s3 bucket
+      test-coverage-upload-bucket:
+        type: string
+        required: false
+        description: |
+          the AWS S3 bucket name to upload test results to.
 jobs:
   go-build:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
@@ -44,6 +54,8 @@ jobs:
     with:
       setup: ${{ inputs.testSetup || inputs.buildSetup }}
       extraArgs: ${{ inputs.goTestExtraArgs }}
+      aws-role-arn-to-assume: ${{ inputs.test-coverage-upload-role }}
+      s3-bucket: ${{ inputs.test-coverage-upload-bucket }}
   go-vet:
     if: ${{ contains(fromJSON('["workflow_call", "workflow_dispatch", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-vet.yml@main

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -2,6 +2,17 @@ name: reusable go test
 on:
   workflow_call:
     inputs:
+      aws-role-arn-to-assume:
+        type: string
+        required: false
+        description: |
+          role to use to upload test results to s3 bucket,
+          see copy-to-s3 action for more detail.
+      s3-bucket:
+        type: string
+        required: false
+        description: |
+          the AWS S3 bucket name to upload test results to.
       setup:
         required: false
         type: string
@@ -39,7 +50,7 @@ jobs:
         id: coverage-html
         run: |
           go tool cover -html=/tmp/coverage.out -o /tmp/coverage.html
-      - name: Upload test log
+      - name: Upload test log to GitHub Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: always()
         with:
@@ -50,3 +61,11 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           overwrite: true
+      - name: Upload test log to S3
+        if: ${{ inputs.aws-role-arn-to-assume && inputs.s3-bucket }}
+        uses: GeoNet/Actions/.github/actions/copy-to-s3@main
+        with:
+          aws-role-arn-to-assume: ${{ inputs.aws-role-arn-to-assume }}
+          artifact-name: test-results
+          artifact-path: ./coverage
+          s3-bucket-uri: s3://${{inputs.s3-bucket}}/test-coverage-results/${{github.repository}}/go/

--- a/README.md
+++ b/README.md
@@ -608,9 +608,13 @@ on:
 jobs:
   go-test:
     uses: GeoNet/Actions/.github/workflows/reusable-go-test.yml@main
+    with:
+      aws-role-arn-to-assume: github-to-s3-upload-role
+      s3-bucket: my-bucket
 ```
 
 test coverage results upload to job artifacts, found at the bottom of a job summary page.
+An optional bucket and role can be provided to upload the results to S3 as well.
 
 ### Go vulnerability check
 


### PR DESCRIPTION
Optional behaviour, when an s3 role and bucket name are provided.

Second attempt at this: https://github.com/GeoNet/Actions/pull/307
Now using a composite action to upload to s3, to avoid workflow nest limits.