### PR TITLE
fix: update cache gh action version

### DIFF
--- a/.github/workflows/reusable-terraform-management.yml
+++ b/.github/workflows/reusable-terraform-management.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           exit 1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins


### PR DESCRIPTION
- move to use the supported version
- tested here: https://github.com/GeoNet/terraform-aws/pull/1439
- related to: https://github.com/actions/cache/discussions/1510