### PR TITLE
nfc: delete unused go.mod file to remove confusion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/GeoNet/Actions
-
-go 1.21


### PR DESCRIPTION
This file is no longer used with the prior removal of test files