### PR TITLE
fix: fail step on non-zero exit code

### DIFF
--- a/.github/workflows/reusable-terraform-management.yml
+++ b/.github/workflows/reusable-terraform-management.yml
@@ -50,6 +50,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        with:
+          terraform_wrapper: false # don't absorb exitcode, propigate it naturally
       - name: Terraform Init
         run: terraform init
       - name: Terraform Format


### PR DESCRIPTION
Currently, terraform errors for `terraform fmt` are not failing the build:
https://github.com/GeoNet/terraform-aws/actions/runs/22419354659/job/64913111658
```
Run terraform fmt -check -diff=true -recursive
╷
│ Error: Unclosed configuration block
│ 
│   on modules/ecs_docker_task_ng/main.tf line 851, in resource "aws_iam_role_policy" "ecs_taskprotection_policy":
│  851: resource "aws_iam_role_policy" "ecs_taskprotection_policy" {
│ 
│ There is no closing brace for this block before the end of the file. This
│ may be caused by incorrect brace nesting elsewhere in this file.
╵
```

The reason this failure still passed was due to the fact that the terraform setup action uses a wrapper by default - this wrapper captures stdout, stderr, and exitcode, and exposes those in outputs:
>terraform_wrapper - (optional) Whether to install a wrapper to wrap subsequent calls of the terraform binary and expose its STDOUT, STDERR, and exit code as outputs named stdout, stderr, and exitcode respectively. Defaults to true.

As none of those outputs are captured / utilised in this workflow, simplest is to disable the wrapper, and have the normal cli fail -> non zero exit code -> build fails process.

