### PR TITLE
feat: update golangci-lint action, and binary version

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           eval '${{ inputs.setup }}'
       - name: golangci-lint
-        uses: GeoNet/golangci-lint-action@1b9b0798df716be5ff7cebc26795b000939a4b41 # master
+        uses: GeoNet/golangci-lint-action@b7bcab6379029e905e3f389a6bf301f1bc220662 # main
         with:
-          version: v1.64.2
+          version: v2.11.3
           args: --timeout 30m -E gosec


### PR DESCRIPTION
This PR uses the recently synced `GeoNet/golangci-lint-action`, and the latest version as at now of the `golangci-lint` binary.
This is to support `go1.25` applications. Tested here: https://github.com/GeoNet/nema-mar-portal/actions
Previous error:
```
Running [/home/runner/golangci-lint-1.64.2-linux-amd64/golangci-lint run  --timeout 30m -E gosec] in [/home/runner/work/nema-mar-portal/nema-mar-portal] ...
  Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25)
  Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25)
  
  Error: golangci-lint exit with code 3
  Ran golangci-lint in 141ms
```

This PR enables the linting to run appropriately now:
```
  Running [/home/runner/golangci-lint-2.11.3-linux-amd64/golangci-lint config path] in [/home/runner/work/nema-mar-portal/nema-mar-portal] ...
  Running [/home/runner/golangci-lint-2.11.3-linux-amd64/golangci-lint run  --timeout 30m -E gosec] in [/home/runner/work/nema-mar-portal/nema-mar-portal] ...
  Error: internal/ui/ui.go:5:12: pattern dist: no matching files found (typecheck)
  //go:embed dist
             ^
  1 issues:
  * typecheck: 1
  
  Error: issues found
  Ran golangci-lint in 27981ms
  ```