### PR TITLE
fix: update CODEOWNERS and dependabot.yml from template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,9 @@
 #
 # Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 #
+# Ensure CODEOWNERS changes are reviewed by an admin
+.github/CODEOWNERS    @GeoNet/Admin
+
+# Ensure all pull requests get a minimum set of reviewers assigned for dependabot
+.github/**/*.yml    @GeoNet/platform-team
+.github/**/*.yaml    @GeoNet/platform-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,6 @@ updates:
     directory: "/"
     commit-message:
       prefix: "fix"
+      prefix-development: "fix"
     schedule:
       interval: "weekly"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
+[settings]
+lockfile = true
+
 [tools]
-go = "1.26.1"
+go = "1.26.2"


### PR DESCRIPTION
This update needs to be applied across all repositories to help manage dependabot PRs.

Update mise.toml for golang version for `mdtoc` run.