### PR TITLE
fix: update actions/checkout to version 6.0.2

### DIFF
--- a/.github/workflows/presubmit-check-action-exists.yml
+++ b/.github/workflows/presubmit-check-action-exists.yml
@@ -6,7 +6,7 @@ jobs:
   check-actions-exist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: run check-actions-exist.sh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/presubmit-workflow-lint.yml
+++ b/.github/workflows/presubmit-workflow-lint.yml
@@ -15,7 +15,7 @@ jobs:
       REQUIRED_STRING_GENERIC: "startsWith(github.repository, 'GeoNet/') == false" # use the steps field and exit 1
       REQUIRED_STRING_APPS: "startsWith(github.repository, 'GeoNet/') != false" # use existing if statements for the chained reuse of workflows, since there's no steps field
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: check for GeoNet org requirement
         run: |
           FAILURES=false
@@ -32,7 +32,7 @@ jobs:
   require-reusable-workflow-is-documented:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: check workflow is documented
         run: |
           FAILURES=false
@@ -48,7 +48,7 @@ jobs:
   require-jobs-run-steps-have-name:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: check for run steps without name
         run: |
           FAILURES=false

--- a/.github/workflows/reusable-container-image-scan.yml
+++ b/.github/workflows/reusable-container-image-scan.yml
@@ -28,7 +28,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: set
         name: require GeoNet org
         run: |
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-copy-to-s3.yml
+++ b/.github/workflows/reusable-copy-to-s3.yml
@@ -66,7 +66,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: get session name
         id: get-session-name
         env:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           # only get golang version we want, and select alpine latest version by default
           echo "image-ref=$( crane ls --full-ref ghcr.io/geonet/base-images/golang | grep ${{steps.setup-go.outputs.go-version}} | sort -V | tail -n 1)" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: default-deployment-tag
         uses: GeoNet/Actions/.github/actions/tagging@main
       - name: Generate deployment tag # TODO can this be combined with default-deployment-tag step?

--- a/.github/workflows/reusable-dockerfile-lint.yml
+++ b/.github/workflows/reusable-dockerfile-lint.yml
@@ -15,7 +15,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: run-info
         name: discover Dockerfiles and Containerfiles
         env:

--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -26,7 +26,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/reusable-github-actions-action-validator.yml
+++ b/.github/workflows/reusable-github-actions-action-validator.yml
@@ -16,7 +16,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: stable

--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -31,7 +31,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -36,7 +36,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-go-vet.yml
+++ b/.github/workflows/reusable-go-vet.yml
@@ -20,7 +20,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-gofmt.yml
+++ b/.github/workflows/reusable-gofmt.yml
@@ -16,7 +16,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-goimports.yml
+++ b/.github/workflows/reusable-goimports.yml
@@ -16,7 +16,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -27,7 +27,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-govulncheck.yml
+++ b/.github/workflows/reusable-govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ inputs.go-version }}

--- a/.github/workflows/reusable-markdown-lint.yml
+++ b/.github/workflows/reusable-markdown-lint.yml
@@ -37,7 +37,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: lint
         name: lint markdown
         env:

--- a/.github/workflows/reusable-presubmit-actions-workflow-require-commit-digest-vet.yml
+++ b/.github/workflows/reusable-presubmit-actions-workflow-require-commit-digest-vet.yml
@@ -9,7 +9,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: actions-per-workflow
         name: discover actions per workflow
         run: |

--- a/.github/workflows/reusable-presubmit-github-actions-workflow-validator.yml
+++ b/.github/workflows/reusable-presubmit-github-actions-workflow-validator.yml
@@ -9,7 +9,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: stable

--- a/.github/workflows/reusable-presubmit-readme-toc.yml
+++ b/.github/workflows/reusable-presubmit-readme-toc.yml
@@ -17,7 +17,7 @@ jobs:
         name: require GeoNet org
         run: |
           exit 1
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: stable

--- a/.github/workflows/sync-actions-forks.yml
+++ b/.github/workflows/sync-actions-forks.yml
@@ -18,7 +18,7 @@ jobs:
   sync-forks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: sync changes
         id: sync-changes
         env:

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Use the full-length commit SHA.
 
 ```yaml
 # UNSAFE: tag can be moved
-- uses: actions/checkout@v4
+- uses: actions/checkout@v4 # unsafe: tag can be removed
 - uses: some-org/some-action@main   # branch refs are worst of all
 
 # SAFE: pinned to immutable SHA
-- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-- uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+- uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 ```
 
 - Principle of least privilege for access to GITHUB_TOKEN and GitHub Secrets values

--- a/USAGE.md
+++ b/USAGE.md
@@ -216,7 +216,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
       - id: set
         run: |
@@ -287,7 +287,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           mkdir -p ./apps/cool-ng/assets
           echo 'hello!' > ./apps/cool-ng/assets/index.html
@@ -1003,7 +1003,7 @@ jobs:
   generate-cool-numbers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: generate
         run: |
           mkdir -p ./outputs/
@@ -1062,7 +1062,7 @@ jobs:
     needs: copy-from-s3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: cool-numbers
@@ -1227,7 +1227,7 @@ jobs:
     outputs:
       tag: ${{ steps.tagging.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: tagging
         uses: GeoNet/Actions/.github/actions/tagging@main
   build:


### PR DESCRIPTION
To maintain our Actions repo we need to upgrade the versions of the main actions we are relying on. Starting with the checkout action.