### PR TITLE
feat: support pnpm in eslint action

### DIFF
--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -30,19 +30,44 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Enable Corepack
+        run: |
+          corepack enable
       - name: Install Node modules
         id: install-node-modules
         env:
           PATHS: ${{ inputs.paths }}
         run: |
+          set -euo pipefail
+      
           for path in $PATHS; do
-            npm install-clean --prefix $path
+            if [ -f "$path/pnpm-lock.yaml" ]; then
+              echo "Using pnpm ($path)"
+              (
+                cd $path
+                pnpm install --frozen-lockfile              
+              )
+            else
+              echo "Using npm ($path)"
+              npm install-clean --prefix $path
+            fi
           done
       - name: Run ESLint
         id: eslint
         env:
           PATHS: ${{ inputs.paths }}
         run: |
+          set -euo pipefail
+      
           for path in $PATHS; do
-            ESLINT_USE_FLAT_CONFIG=true $path/node_modules/.bin/eslint -c $path/eslint.config.mjs $path
+            if [ -f "$path/pnpm-lock.yaml" ]; then
+              echo "Using eslint with pnpm ($path)"
+              (
+                cd $path
+                ESLINT_USE_FLAT_CONFIG=true pnpm exec eslint -c eslint.config.mjs .
+              )
+            else
+              echo "Using eslint with npm ($path)"
+              ESLINT_USE_FLAT_CONFIG=true $path/node_modules/.bin/eslint -c $path/eslint.config.mjs $path
+            fi
           done


### PR DESCRIPTION
Grafana plugins in `grafdash` use pnpm for dependency management, rather than npm. npm used to work on pnpm-lock.yaml files in this linting workflow, but now it doesn't. enabling corepack means the package manger defined in package.json  will be installed - in grafdash's case this is pnpm. Other projects are all npm, and don't define a packageManager, however npm comes along with node so they should still work.

Tested with pnpm project: https://github.com/GeoNet/grafdash/actions/runs/25642799740/job/75267205661
Tested with existing npm project: https://github.com/GeoNet/tilde/actions/runs/25643237576/job/75267184290?pr=369