### PR TITLE
fix: handle image URI which combine both tag and digest

### DIFF
--- a/.github/workflows/reusable-aws-deploy.yml
+++ b/.github/workflows/reusable-aws-deploy.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Save deployment information
         if: inputs.deployment-type != ''
         run: |
-          IMAGE_TAG=$(echo ${{ inputs.image }} | cut -d':' -f 2)
+          IMAGE_TAG=$(echo ${{ inputs.image }} | cut -d':' -f 2 | cut -d'@' -f 1)
           aws ssm put-parameter \
             --name ${{ inputs.deployment-tag-param-name }} \
             --value $(jq -cn --arg image-tag $IMAGE_TAG --arg task-arn ${{ steps.task-deploy.outputs.task-definition-arn }} '$ARGS.named') \


### PR DESCRIPTION
Allows correct extraction of tag-only for full image URI which contain both tag and digest. Previous behaviour result in a tag like `git123456@sha`.