### PR TITLE
feat: update mise add zizmor and pinact for security checks

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -10,12 +10,22 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 provenance = "github-attestations"
 
 [[tools.go]]
-version = "1.26.2"
+version = "1.26.5"
 backend = "core:go"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
-url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
+
+[[tools.pinact]]
+version = "4.1.0"
+backend = "aqua:suzuki-shunsuke/pinact"
+
+[tools.pinact."platforms.linux-x64"]
+checksum = "sha256:8fcbf1b3e95551c82fd995535e3c1defa70e23299ce36eb3afd6c98778de6ca0"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/suzuki-shunsuke/pinact/releases/assets/442249966"
+provenance = "github-attestations"
 
 [[tools.shellcheck]]
 version = "0.11.0"
@@ -24,3 +34,13 @@ backend = "aqua:koalaman/shellcheck"
 [tools.shellcheck."platforms.linux-x64"]
 checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+
+[[tools.zizmor]]
+version = "1.26.1"
+backend = "aqua:zizmorcore/zizmor"
+
+[tools.zizmor."platforms.linux-x64"]
+checksum = "sha256:8556289a64e7aaf2400cd516f61a471aa91c5902cc56ad96a82fd12f90c2ef73"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417985"
+provenance = "github-attestations"

--- a/mise.toml
+++ b/mise.toml
@@ -3,5 +3,7 @@ lockfile = true
 
 [tools]
 actionlint = "1.7.12"
-go = "1.26.2"
+go = "1.26.5"
+pinact = "4.1.0"
 shellcheck = "0.11.0"
+zizmor = "1.26.1"


### PR DESCRIPTION
Add zizmor for scanning for issues in GitHub Actions workflows. Zizmor will provide recommendations for secure configuration and best practice.
- https://github.com/zizmorcore/zizmor
- https://docs.zizmor.sh/

Add pinact for quick and easy version updates for pinned version strings for GitHub Actions.
- https://github.com/suzuki-shunsuke/pinact

Bump Go version for security fixes to the crypto/tls and os packages (used for the TOC markdown tool)