### PR TITLE
feat: allow errors to be ignored for JS linting

### DIFF
--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -39,13 +39,13 @@ jobs:
           PATHS: ${{ inputs.paths }}
         run: |
           set -euo pipefail
-      
+
           for path in $PATHS; do
             if [ -f "$path/pnpm-lock.yaml" ]; then
               echo "Using pnpm ($path)"
               (
                 cd $path
-                pnpm install --frozen-lockfile              
+                pnpm install --frozen-lockfile
               )
             else
               echo "Using npm ($path)"
@@ -58,7 +58,7 @@ jobs:
           PATHS: ${{ inputs.paths }}
         run: |
           set -euo pipefail
-      
+
           for path in $PATHS; do
             if [ -f "$path/pnpm-lock.yaml" ]; then
               echo "Using eslint with pnpm ($path)"

--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -18,6 +18,13 @@ on:
           running eslint.
           See https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax
           for syntax.
+      ignore-errors:
+        type: boolean
+        default: false
+        description: |
+          Ignore linting errors. Useful when migrating projects to use linting for the first time,
+          allowing errors to be handled over time.
+
 jobs:
   eslint:
     runs-on: ubuntu-latest
@@ -54,6 +61,7 @@ jobs:
           done
       - name: Run ESLint
         id: eslint
+        continue-on-error: ${{ inputs.ignore-errors }}
         env:
           PATHS: ${{ inputs.paths }}
         run: |


### PR DESCRIPTION
When onboarding projects to use linting, useful to be able to suppress errors to allow builds to still be successful.
Note: even when errors are explicitly ignored by the calling workflow, we still get reporting on them:
https://github.com/GeoNet/tilde/actions/runs/30586891104