### PR TITLE
nfc: remove redunant required field

### DIFF
--- a/.github/workflows/reusable-eslint.yml
+++ b/.github/workflows/reusable-eslint.yml
@@ -10,7 +10,6 @@ on:
           configuration file (eslint.config.mjs) exist.
           e.g.: my/root/one my/cool/root/two
       node-version:
-        required: false
         type: string
         default: "21.x"
         description: |


### PR DESCRIPTION
`required: true` not needed if default value is provided.
Addresses https://github.com/GeoNet/Actions/pull/398#pullrequestreview-4824258211, in an indirect way